### PR TITLE
Tweaked a comparison statement

### DIFF
--- a/m3uparser.py
+++ b/m3uparser.py
@@ -18,7 +18,7 @@ class track():
     ..\Minus The Bear - Planet of Ice\Minus The Bear_Planet of Ice_01_Burying Luck.mp3
 """
 
-def parsem3u(infile):
+def parseM3U(infile):
     try:
         assert(type(infile) == '_io.TextIOWrapper')
     except AssertionError:

--- a/m3uparser.py
+++ b/m3uparser.py
@@ -1,6 +1,7 @@
 # more info on the M3U file format available here:
 # http://n4k3d.com/the-m3u-file-format/
 
+import _io
 import sys
 
 class track():
@@ -20,7 +21,7 @@ class track():
 
 def parseM3U(infile):
     try:
-        assert(type(infile) == '_io.TextIOWrapper')
+        assert(type(infile) == _io.TextIOWrapper)
     except AssertionError:
         infile = open(infile,'r')
 


### PR DESCRIPTION
Comparing type(infile) with string '_io.TextIOWrapper' will always give False because if infile is a type of _io.TextIOWrapper class, then type(infile) returns <class '_io.TextIOWrapper'> not '_io.TextIOWrapper'

